### PR TITLE
Support inheritance, add Optional & mutability tests

### DIFF
--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -1,0 +1,71 @@
+import json
+from typing import Optional
+
+from implicitdict import ImplicitDict
+
+
+class MyData(ImplicitDict):
+    foo: str
+    bar: int = 0
+    baz: Optional[float]
+    has_default_baseclass: str = "In MyData"
+
+    def hello(self) -> str:
+        return "MyData"
+
+    def base_method(self) -> int:
+        return 123
+
+
+class MySubclass(MyData):
+    buzz: Optional[str]
+    has_default_subclass: str = "In MySubclass"
+
+    def hello(self) -> str:
+        return "MySubclass"
+
+
+def test_inheritance():
+    data: MyData = ImplicitDict.parse({'foo': 'asdf', 'bar': 1}, MyData)
+    assert json.loads(json.dumps(data)) == {"foo": "asdf", "bar": 1, "has_default_baseclass": "In MyData"}
+    assert data.hello() == "MyData"
+    assert data.has_default_baseclass == "In MyData"
+
+    subclass: MySubclass = ImplicitDict.parse(json.loads(json.dumps(data)), MySubclass)
+    assert subclass.foo == "asdf"
+    assert subclass.bar == 1
+    assert "baz" not in subclass
+    assert subclass.hello() == "MySubclass"
+    assert subclass.base_method() == 123
+    subclass.buzz = "burrs"
+    assert subclass.has_default_baseclass == "In MyData"
+    assert subclass.has_default_subclass == "In MySubclass"
+    subclass.has_default_baseclass = "In MyData 2"
+    subclass.has_default_subclass = "In MySubclass 2"
+
+    subclass = MySubclass(data)
+    assert subclass.foo == "asdf"
+    assert subclass.bar == 1
+    assert "baz" not in subclass
+    assert subclass.hello() == "MySubclass"
+    assert subclass.base_method() == 123
+    assert "buzz" not in subclass
+    subclass.buzz = "burrs"
+    assert subclass.has_default_baseclass == "In MyData"
+    assert subclass.has_default_subclass == "In MySubclass"
+    subclass.has_default_baseclass = "In MyData 3"
+    subclass.has_default_subclass = "In MySubclass 3"
+
+    data2 = MyData(subclass)
+    assert data2.foo == "asdf"
+    assert data2.bar == 1
+    assert "baz" not in data2
+    assert data2.hello() == "MyData"
+    assert "buzz" not in data2
+    assert data2.has_default_baseclass == "In MyData 3"
+    data2.has_default_baseclass = "In MyData 4"
+
+    subclass2 = MySubclass(subclass)
+    assert subclass2.buzz == "burrs"
+    assert subclass.has_default_baseclass == "In MyData 3"
+    assert subclass.has_default_subclass == "In MySubclass 3"

--- a/tests/test_mutability.py
+++ b/tests/test_mutability.py
@@ -1,0 +1,56 @@
+import json
+from typing import Optional, List
+
+from implicitdict import ImplicitDict
+
+
+class MyData(ImplicitDict):
+    primitive: str
+    list_of_primitives: List[str]
+    generic_dict: dict
+    subtype: Optional["MyData"]
+
+
+def test_mutability_from_constructor():
+    primitive = 'foobar'
+    primitive_list = ['one', 'two']
+    generic_dict = {'level1': 'foo', 'level2': {'bar': 'baz'}}
+    data = MyData(primitive=primitive, list_of_primitives=primitive_list, generic_dict=generic_dict)
+    assert data.primitive == primitive
+    assert data.list_of_primitives == primitive_list
+    assert data.generic_dict == generic_dict
+
+    primitive = 'foobar2'
+    assert data.primitive != primitive
+
+    primitive_list[1] = 'three'
+    assert data.list_of_primitives[1] == 'three'
+
+    generic_dict['level1'] = 'bar'
+    assert data.generic_dict['level1'] == 'bar'
+
+    generic_dict['level2']['bar'] = 'buzz'
+    assert data.generic_dict['level2']['bar'] == 'buzz'
+
+
+def test_mutability_from_parse():
+    primitive = 'foobar'
+    primitive_list = ['one', 'two']
+    generic_dict = {'level1': 'foo', 'level2': {'bar': 'baz'}}
+    data_source = MyData(primitive=primitive, list_of_primitives=primitive_list, generic_dict=generic_dict)
+    data: MyData = ImplicitDict.parse(data_source, MyData)
+    assert data.primitive == primitive
+    assert data.list_of_primitives == primitive_list
+    assert data.generic_dict == generic_dict
+
+    primitive = 'foobar2'
+    assert data.primitive != primitive
+
+    primitive_list[1] = 'three'
+    assert data.list_of_primitives[1] == 'three'
+
+    generic_dict['level1'] = 'bar'
+    assert data.generic_dict['level1'] == 'foo'  # <-- dicts are reconstructed with `parse`
+
+    generic_dict['level2']['bar'] = 'buzz'
+    assert data.generic_dict['level2']['bar'] == 'buzz'

--- a/tests/test_optional.py
+++ b/tests/test_optional.py
@@ -1,0 +1,130 @@
+import json
+from typing import Optional
+
+import pytest
+
+from implicitdict import ImplicitDict
+
+
+class MyData(ImplicitDict):
+    required_field: str
+    optional_field1: Optional[str]
+    field_with_default: str = "default value"
+    optional_field2_with_none_default: Optional[str] = None
+    optional_field3_with_default: Optional[str] = "concrete default"
+
+
+def test_fully_defined():
+    data = MyData(
+        required_field="foo1",
+        optional_field1="foo2",
+        field_with_default="foo3",
+        optional_field2_with_none_default="foo4",
+        optional_field3_with_default="foo5",
+    )
+    assert "required_field" in data
+    assert "optional_field1" in data
+    assert "field_with_default" in data
+    assert "optional_field2_with_none_default" in data
+    assert "optional_field3_with_default" in data
+    s = json.dumps(data)
+    assert "required_field" in s
+    assert "optional_field1" in s
+    assert "field_with_default" in s
+    assert "optional_field2" in s
+    assert "optional_field3" in s
+    assert "foo1" in s
+    assert "foo2" in s
+    assert "foo3" in s
+    assert "foo4" in s
+    assert "foo5" in s
+
+
+def test_minimally_defined():
+    # An unspecified optional field will not be present in the object at all
+    data = MyData(required_field="foo1")
+    assert "required_field" in data
+    assert "optional_field1" not in data
+    assert "field_with_default" in data
+    assert "optional_field2_with_none_default" in data
+    assert "optional_field3_with_default" in data
+    with pytest.raises(KeyError):
+        # Trying to reference the Optional field will result in a KeyError
+        # To determine whether an Optional field is present, the user must check
+        # whether `"<FIELD_NAME>" in <OBJECT>` (see above).
+        assert data.optional_field1 == None
+    s = json.dumps(data)
+    assert "required_field" in s
+    assert "optional_field1" not in s
+    assert "field_with_default" in s
+    assert "optional_field2" in s
+    assert "optional_field3" in s
+    assert "foo1" in s
+
+
+def test_provide_optional_field():
+    data = MyData(required_field="foo1", optional_field1="foo2")
+    assert "required_field" in data
+    assert "optional_field1" in data
+    assert "field_with_default" in data
+    assert "optional_field2_with_none_default" in data
+    assert "optional_field3_with_default" in data
+    s = json.dumps(data)
+    assert "required_field" in s
+    assert "optional_field1" in s
+    assert "field_with_default" in s
+    assert "optional_field2" in s
+    assert "optional_field3" in s
+    assert "foo1" in s
+    assert "foo2" in s
+
+
+def test_provide_optional_field_as_none():
+    # If an optional field with no default is explicitly provided as None, then that field will not be included in the object
+    data = MyData(required_field="foo1", optional_field1=None)
+    assert "required_field" in data
+    assert "optional_field1" not in data  # <--
+    assert "field_with_default" in data
+    assert "optional_field2_with_none_default" in data
+    assert "optional_field3_with_default" in data
+    s = json.dumps(data)
+    assert "required_field" in s
+    assert "optional_field1" not in s  # <--
+    assert "field_with_default" in s
+    assert "optional_field2" in s
+    assert "optional_field3" in s
+    assert "foo1" in s
+
+
+def test_provide_optional_field_with_none_default_as_none():
+    # If a field has a default value, the field will always be present in the object, even if that default value is None and the field is Optional
+    data = MyData(required_field="foo1", optional_field2_with_none_default=None)
+    assert "required_field" in data
+    assert "optional_field1" not in data
+    assert "field_with_default" in data
+    assert "optional_field2_with_none_default" in data  # <--
+    assert "optional_field3_with_default" in data
+    s = json.dumps(data)
+    assert "required_field" in s
+    assert "optional_field1" not in s
+    assert "field_with_default" in s
+    assert "optional_field2" in s  # <--
+    assert "optional_field3" in s
+    assert "foo1" in s
+
+
+def test_provide_optional_field_with_default_as_none():
+    # If a field has a default value, the field will always be present in the object
+    data = MyData(required_field="foo1", optional_field3_with_default=None)
+    assert "required_field" in data
+    assert "optional_field1" not in data
+    assert "field_with_default" in data
+    assert "optional_field2_with_none_default" in data
+    assert "optional_field3_with_default" in data  # <--
+    s = json.dumps(data)
+    assert "required_field" in s
+    assert "optional_field1" not in s
+    assert "field_with_default" in s
+    assert "optional_field2" in s
+    assert "optional_field3" in s  # <--
+    assert "foo1" in s


### PR DESCRIPTION
This PR enhances ImplicitDict to support inherited classes (see `test_inheritance.py`).  It also adds behavior documentation in the form of tests for Optional fields and mutability.