### PR TITLE
Fix future annotations bug

### DIFF
--- a/src/implicitdict/__init__.py
+++ b/src/implicitdict/__init__.py
@@ -233,7 +233,7 @@ def _get_fields(subtype: Type) -> Tuple[Set[str], Set[str]]:
                 optional_fields = optional_fields.union(ancestor_optional_fields)
 
         # Enumerate all fields defined for the subclass
-        annotations = subtype.__annotations__ if hasattr(subtype, '__annotations__') else {}
+        annotations = get_type_hints(subtype)
         for key in annotations:
             all_fields.add(key)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+import os
+import shutil
+
+
+def _duplicate_tests_with_future_annotations():
+    # Type annotations have different behavior with and without the declaration
+    # of using the future style.  Duplicate the tests with future annotations to
+    # ensure consistent behavior.
+    this_folder = os.path.dirname(__file__)
+    future_annotations_folder = os.path.join(this_folder, 'future_annotations')
+    os.makedirs(future_annotations_folder, exist_ok=True)
+    with open(os.path.join(future_annotations_folder, '__init__.py'), 'w') as f:
+        pass
+    for filename in os.listdir(this_folder):
+        if (filename.startswith('test_') and filename.endswith('.py')) or filename.endswith('_test.py'):
+            with open(os.path.join(this_folder, filename), 'r') as f:
+                code = f.read()
+            with open(os.path.join(future_annotations_folder, filename), 'w') as f:
+                f.write('from __future__ import annotations\n')
+                f.write(code)
+        # TODO: recurse into subfolders if/when subfolders are created
+
+
+def _remove_future_annotations_tests():
+    this_folder = os.path.dirname(__file__)
+    future_annotations_folder = os.path.join(this_folder, 'future_annotations')
+    shutil.rmtree(future_annotations_folder)
+
+
+def pytest_configure(config):
+    _duplicate_tests_with_future_annotations()
+
+
+def pytest_unconfigure(config):
+    _remove_future_annotations_tests()


### PR DESCRIPTION
This PR first adds failing tests due to `from __future__ import annotations` (which causes type annotations to be strings rather than Types) by duplicating all existing tests into a subfolder after adding a prefix line of `from __future__ import annotations`.  Then, the bug is fixed with a one-line change to ImplicitDict logic.