### PR TITLE
Change __getattribute__ to raise AttributeErrors instead of KeyErrors

### DIFF
--- a/src/implicitdict/__init__.py
+++ b/src/implicitdict/__init__.py
@@ -152,7 +152,10 @@ class ImplicitDict(dict):
             self_type_name = _fullname(self_type)
             if self_type_name in fields_info_by_type:
                 if item in fields_info_by_type[self_type_name].all_fields:
-                    return self[item]
+                    try:
+                        return self[item]
+                    except KeyError:
+                        raise AttributeError
         return super(ImplicitDict, self).__getattribute__(item)
 
     def __setattr__(self, key, value):
@@ -165,7 +168,7 @@ class ImplicitDict(dict):
                     self[key] = value
                     return
                 else:
-                    raise KeyError('Attribute "{}" is not defined for "{}" object'.format(key, type(self).__name__))
+                    raise AttributeError('Attribute "{}" is not defined for "{}" object'.format(key, type(self).__name__))
         super(ImplicitDict, self).__setattr__(key, value)
 
     def has_field_with_value(self, field_name: str) -> bool:

--- a/tests/test_normal_usage.py
+++ b/tests/test_normal_usage.py
@@ -23,7 +23,7 @@ def test_basic_usage():
 
     # Optional fields that aren't specified simply don't exist
     assert 'baz' not in data
-    with pytest.raises(KeyError):
+    with pytest.raises(AttributeError):
         assert data.baz == 0
 
     # Optional fields can be omitted (fields with defaults are optional)

--- a/tests/test_optional.py
+++ b/tests/test_optional.py
@@ -42,8 +42,8 @@ def test_minimally_defined():
     assert "field_with_default" in data
     assert "optional_field2_with_none_default" in data
     assert "optional_field3_with_default" in data
-    with pytest.raises(KeyError):
-        # Trying to reference the Optional field will result in a KeyError
+    with pytest.raises(AttributeError):
+        # Trying to reference the Optional field will result in a AttributeError
         # To determine whether an Optional field is present, the user must check
         # whether `"<FIELD_NAME>" in <OBJECT>` (see above).
         assert data.optional_field1 == None

--- a/tests/test_optional.py
+++ b/tests/test_optional.py
@@ -55,6 +55,13 @@ def test_minimally_defined():
     assert "optional_field3" in s
     assert "foo1" in s
 
+def test_getattr():
+    """Test that getattr is returning default value undefined fields"""
+
+    data = OptionalData.example_values()["minimally_defined"]
+    assert "optional_field1" not in data
+    assert getattr(data, "optional_field1", "getattrdefault") == "getattrdefault"
+
 
 def test_provide_optional_field():
     data = OptionalData.example_values()["provide_optional_field"]


### PR DESCRIPTION
This PR fixes `__getattribute__` by raising a `AttributeError` instead of a `KeyError`.

This is a breaking change is usage of this library expect a `KeyError`.

Rationale behind this proposition:

- We're getting an attribute in `__getattribute__`'s context, so a `KeyError` is not really correct.
- The fact that the wrong error is generated break python `getattr` function with a default, who stop at the `KeyError` exception and doesn't return the default value provider.
- This problem is linked to this issue: https://github.com/interuss/monitoring/issues/974

If we don't want to break behavior like that, we could also handle that on the interuss/monitoring side, but I would suggest to fix the root cause :)