### PR TITLE
[tooling] Remove redundant workflow, update and fix CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-13, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        pip-install-options: ["", " -e"]
         exclude: # https://github.com/actions/setup-python/issues/875
           - os: macos-latest
             python-version: "3.8"
@@ -25,7 +26,7 @@ jobs:
           - os: macos-latest
             python-version: "3.10"
       max-parallel: 3
-    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}${{ matrix.pip-install-options }}
     steps:
     - uses: actions/checkout@v3
     - name: setup-python
@@ -36,6 +37,6 @@ jobs:
     - name: confirm pip version
       run: pip --version
     - name: installation
-      run: pip install .[dev]
+      run: pip install ${{ matrix.pip-install-options }} .[dev]
     - name: test
       run: python -m pytest --cov

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,10 +15,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, macos-13, macos-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        exclude: # https://github.com/actions/setup-python/issues/875
+          - os: macos-latest
+            python-version: "3.8"
+          - os: macos-latest
+            python-version: "3.9"
+          - os: macos-latest
+            python-version: "3.10"
       max-parallel: 3
-    name: Python ${{ matrix.python-version }}
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - name: setup-python

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
       max-parallel: 3
     name: Python ${{ matrix.python-version }}
     steps:
@@ -30,26 +30,5 @@ jobs:
       run: pip --version
     - name: installation
       run: pip install .[dev]
-    - name: test
-      run: python -m pytest --cov
-  editable-install-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8"]
-      max-parallel: 3
-    name: Python ${{ matrix.python-version }}
-    steps:
-    - uses: actions/checkout@v3
-    - name: setup-python
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-        architecture: "x64"
-    - name: confirm pip version
-      run: pip --version
-    - name: installation
-      run: pip install -e .[dev]
     - name: test
       run: python -m pytest --cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ authors = [
 description = "ImplicitDict base class that turns a subclass into a dict indexing attributes, making [de]serialization easy for complex typing-annotated data types."
 readme = "README.md"
 license = { file = "LICENSE.md" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",
@@ -37,7 +37,7 @@ classifiers = [
 ]
 dependencies = ["arrow", "jsonschema", "pytimeparse"]
 [project.optional-dependencies]
-dev = ["pytest==5.0.0", "pytest-cov[all]", "black==21.10b0"]
+dev = ["pytest==8.3.4", "pytest-cov[all]", "black==25.1.0"]
 [project.urls]
 "Homepage" = "https://github.com/interuss/implicitdict"
 "Bug Tracker" = "https://github.com/interuss/implicitdict/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ authors = [
 description = "ImplicitDict base class that turns a subclass into a dict indexing attributes, making [de]serialization easy for complex typing-annotated data types."
 readme = "README.md"
 license = { file = "LICENSE.md" }
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 dependencies = ["arrow", "jsonschema", "pytimeparse"]
 [project.optional-dependencies]
-dev = ["pytest==8.3.4", "pytest-cov[all]", "black==25.1.0"]
+dev = ["pytest==8.3.4", "pytest-cov[all]", "black==24.8.0"]
 [project.urls]
 "Homepage" = "https://github.com/interuss/implicitdict"
 "Bug Tracker" = "https://github.com/interuss/implicitdict/issues"


### PR DESCRIPTION
This PR updates the CI configuration by:
* Removing a job that is identical (except for matrix on Python version) to an earlier job
* Adding newer Python support through 3.12
* Updating matrix to test both macos-13 (x86) and macos-latest (arm), but omitting Python <3.11 on macos-latest due to [issue](https://github.com/actions/setup-python/issues/875)
* Updating dependency versions to fix bug