### PR TITLE
[bug] Fix #13 (regex freeze with certain content)

### DIFF
--- a/src/implicitdict/jsonschema.py
+++ b/src/implicitdict/jsonschema.py
@@ -197,9 +197,9 @@ def _field_docs_for(t: Type[ImplicitDict]) -> Dict[str, str]:
     # Curse Guido for rejecting PEP224!  Fine, we'll do it ourselves.
     result = {}
     src = inspect.getsource(t)
-    doc_pattern = r"\n\s+([_a-zA-Z][_a-zA-Z0-9]*)(?:: [^\n]+)?\n(\s+)(?:\"\"\"|''')((?:.|\s)*?)(?:\"\"\"|''')"
+    doc_pattern = r"\n([ \t]+)([_a-zA-Z][_a-zA-Z0-9]*)(?:: [^\n]+)?\n\1(?:\"\"\"|''')((?:.|\s)*?)(?:\"\"\"|''')"
     for m in re.finditer(doc_pattern, src):
-        indent = m.group(2)
+        indent = m.group(1)
         lines = m.group(3).split("\n")
         for i in range(1, len(lines)):
             if lines[i].startswith(indent):
@@ -207,5 +207,5 @@ def _field_docs_for(t: Type[ImplicitDict]) -> Dict[str, str]:
         while not lines[-1]:
             lines = lines[0:-1]
         docstring = "\n".join(lines)
-        result[m.group(1)] = docstring
+        result[m.group(2)] = docstring
     return result

--- a/tests/test_docpattern.py
+++ b/tests/test_docpattern.py
@@ -45,7 +45,6 @@ def test_docpattern():
     def perform_test():
         repo = {}
         make_json_schema(Query, lambda t: SchemaVars(name=t.__name__), repo)
-        print(repo)
     test_process = multiprocessing.Process(target=perform_test, args=[])
     test_process.start()
     test_process.join(timeout=1)

--- a/tests/test_docpattern.py
+++ b/tests/test_docpattern.py
@@ -1,0 +1,52 @@
+import multiprocessing
+from typing import List, Optional, Type
+from implicitdict import ImplicitDict
+from implicitdict.jsonschema import make_json_schema, SchemaVars
+
+
+class ResponseType(ImplicitDict):
+    pass
+
+
+class Query(ImplicitDict):
+
+    participant_id: Optional[str]
+    """If specified, identifier of the USS/participant hosting the server involved in this query."""
+
+    def parse_json_result(self, parse_type: Type[ResponseType]) -> ResponseType:
+        """Parses the JSON result into the specified type.
+
+        Args:
+            parse_type: ImplicitDict type to parse into.
+        Returns:
+             the parsed response (of type `parse_type`).
+        Raises:
+            QueryError: if the parsing failed.
+        """
+        try:
+            return parse_type(ImplicitDict.parse(self.response.json, parse_type))
+        except (ValueError, TypeError, KeyError) as e:
+            raise QueryError(
+                f"Parsing JSON response into type {parse_type.__name__} failed with exception {type(e).__name__}: {e}",
+                self,
+            )
+
+
+class QueryError(RuntimeError):
+    """Error encountered when interacting with a server in the UTM ecosystem."""
+
+    queries: List[Query]
+
+
+def test_docpattern():
+    """Tests issue #13 'Regex gets incorrect matches'"""
+
+    # Perform actual test in separate process with timeout
+    def perform_test():
+        repo = {}
+        make_json_schema(Query, lambda t: SchemaVars(name=t.__name__), repo)
+        print(repo)
+    test_process = multiprocessing.Process(target=perform_test, args=[])
+    test_process.start()
+    test_process.join(timeout=1)
+    assert test_process.exitcode is not None, "make_json_schema did not complete within the time limit"


### PR DESCRIPTION
This PR should resolve #13.

First, it establishes a test that fails due to #13.  The regex happens to be incorrect, but the core issue appears to be that the built-in Python regex library freezes when attempting to search for the second instance of the pattern match.  The test detects this freeze by running the problematic operation in a separate process (separate thread is insufficient; test freezes if the operation is merely in a separate thread) and expecting the operation to complete within a second.  When the regex search freezes, there is no exit code and the test fails.

Second, it fixes the bug by updating the regex to look for a consistent indent between the property declaration and the docstring for that property (and clarifies that indents are composed only of spaces and tabs, not any other whitespace like newline).