### PR TITLE
Handle new coding style for optional fields (drop python < 3.10 support)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,13 +16,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-13, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         pip-install-options: ["", " -e"]
         exclude: # https://github.com/actions/setup-python/issues/875
-          - os: macos-latest
-            python-version: "3.8"
-          - os: macos-latest
-            python-version: "3.9"
           - os: macos-latest
             python-version: "3.10"
       max-parallel: 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ authors = [
 description = "ImplicitDict base class that turns a subclass into a dict indexing attributes, making [de]serialization easy for complex typing-annotated data types."
 readme = "README.md"
 license = { file = "LICENSE.md" }
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",

--- a/src/implicitdict/__init__.py
+++ b/src/implicitdict/__init__.py
@@ -7,6 +7,7 @@ import datetime
 from datetime import datetime as datetime_type
 from typing import get_args, get_origin, get_type_hints, Dict, Literal, \
     Optional, Type, Union, Set, Tuple
+from types import UnionType
 
 import pytimeparse
 
@@ -207,7 +208,7 @@ def _parse_value(value, value_type: Type):
                 result[parsed_key] = parsed_value
             return result
 
-        elif generic_type is Union and len(arg_types) == 2 and arg_types[1] is type(None):
+        elif (generic_type is Union or generic_type is UnionType) and len(arg_types) == 2 and arg_types[1] is type(None):
             # Type is an Optional declaration
             if value is None:
                 # An optional field specified explicitly as None is equivalent to
@@ -292,7 +293,7 @@ def _get_fields(subtype: Type) -> Tuple[Set[str], Set[str]]:
             generic_type = get_origin(field_type)
             if generic_type is Optional:
                 optional_fields.add(key)
-            elif generic_type is Union:
+            elif generic_type is Union or generic_type is UnionType:
                 generic_args = get_args(field_type)
                 if len(generic_args) == 2 and generic_args[1] is type(None):
                     optional_fields.add(key)

--- a/src/implicitdict/jsonschema.py
+++ b/src/implicitdict/jsonschema.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import enum
 import json
 import re
+from types import UnionType
 from typing import get_args, get_origin, get_type_hints, Dict, Literal, Optional, Type, Union, Tuple, Callable
 
 from . import ImplicitDict, _fullname, _get_fields, StringBasedDateTime, StringBasedTimeDelta
@@ -138,7 +139,7 @@ def _schema_for(value_type: Type, schema_vars_resolver: SchemaVarsResolver, sche
                 schema["additionalProperties"] = value_schema
             return schema, False
 
-        elif generic_type is Union and len(arg_types) == 2 and arg_types[1] is type(None):
+        elif (generic_type is Union or generic_type is UnionType) and len(arg_types) == 2 and arg_types[1] is type(None):
             # Type is an Optional declaration
             subschema, _ = _schema_for(arg_types[0], schema_vars_resolver, schema_repository, context)
             schema = json.loads(json.dumps(subschema))

--- a/tests/test_optional.py
+++ b/tests/test_optional.py
@@ -25,6 +25,7 @@ def test_fully_defined():
     assert "foo3" in s
     assert "foo4" in s
     assert "foo5" in s
+    assert "foo6" in s
 
 
 def test_over_defined():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -103,6 +103,7 @@ class OptionalData(ImplicitDict):
     field_with_default: str = "default value"
     optional_field2_with_none_default: Optional[str] = None
     optional_field3_with_default: Optional[str] = "concrete default"
+    new_style_optional: str | None
 
     @staticmethod
     def example_values():
@@ -113,6 +114,7 @@ class OptionalData(ImplicitDict):
                 field_with_default="foo3",
                 optional_field2_with_none_default="foo4",
                 optional_field3_with_default="foo5",
+                new_style_optional="foo6",
             ),
             "over_defined": OptionalData(
                 required_field="foo1",
@@ -120,7 +122,8 @@ class OptionalData(ImplicitDict):
                 field_with_default="foo3",
                 optional_field2_with_none_default="foo4",
                 optional_field3_with_default="foo5",
-                unknown_field="foo6",
+                new_style_optional="foo6",
+                unknown_field="foo7",
             ),
             "minimally_defined": OptionalData(required_field="foo1"),
             "provide_optional_field": OptionalData(required_field="foo1", optional_field1="foo2"),


### PR DESCRIPTION
[PEP604](https://peps.python.org/pep-0604/ ) introduced a new, cleaner version of declaration for optional field that [some tools](https://docs.astral.sh/ruff/rules/non-pep604-annotation-optional/) like to enforce.

This make the library compatible with such usage, it has been tested on the upgraded [monitoring](https://github.com/interuss/monitoring) code base.

This has the consequence of dropping python < 3.10 support. Python 3.9 will be EOL in two month, so I assumed it's fine, but it's possible to make the code compatible at the cost of readability ^^'