### PR TITLE
 [tooling] Update license definition in project file 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [build-system]
 requires = [
-  "setuptools>=64",
+  "setuptools>=77.0.3",
   "wheel",               # for bdist package distribution
   "setuptools_scm>=6.4", # for automated versioning
 ]
@@ -28,11 +28,10 @@ authors = [
 ]
 description = "ImplicitDict base class that turns a subclass into a dict indexing attributes, making [de]serialization easy for complex typing-annotated data types."
 readme = "README.md"
-license = { file = "LICENSE.md" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]
 dependencies = [


### PR DESCRIPTION
Follow #20 and #18 (to drop old python support)

Update the license definition in the project file.

Remove the warning that was shown in builds:

```
 !!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
```
